### PR TITLE
Add metadata for better preview cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,26 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
+    <meta name="description" content="We believe Open Source is for everyone, yes you!">
+
+    <!-- Google / Search Engine Tags -->
+    <meta itemprop="name" content="Eddie Jaoude Community">
+    <meta itemprop="description" content="We believe Open Source is for everyone, yes you!">
+    <meta itemprop="image" content="https://eddiehubcommunity.github.io/img/hero.svg">
+    
+    <!-- Facebook Meta Tags -->
+    <meta property="og:url" content="https://eddiehubcommunity.github.io">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Eddie Jaoude Community">
+    <meta property="og:description" content="We believe Open Source is for everyone, yes you!">
+    <meta property="og:image" content="https://eddiehubcommunity.github.io/img/hero.svg">
+    
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Eddie Jaoude Community">
+    <meta name="twitter:description" content="We believe Open Source is for everyone, yes you!">
+    <meta name="twitter:image" content="https://eddiehubcommunity.github.io/img/hero.svg">
+
     <title>Eddie Jaoude Community</title>
 
     <link rel="icon" type="image/ico" href="./favicon.ico" />


### PR DESCRIPTION
This PR fixes issue #124 and #116 

- Add meta tags for google search engine and meta description for Facebook and twitter 
- Should generate correct cards when sharing website in any social media or messaging platform 