### PR TITLE
Fix: Broken link 🔗

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -88,7 +88,7 @@ export const projects = [
     name: 'EddieBot Map',
     imageSrc: 'https://user-images.githubusercontent.com/624760/91445888-9f9af280-e86e-11ea-8180-9198953bc33d.png',
     description: 'Live streaming background with a map and maybe more ...',
-    link: 'https://github.com/EddieHubCommunity/EddieBotMap',
+    link: 'https://github.com/EddieHubCommunity/EddieBotLive',
     techList: [
       techIconsData.javascript,
       techIconsData.angular,


### PR DESCRIPTION
This link is broken because the project name is changed
https://github.com/EddieHubCommunity/EddieBotMap

So I changed it to the new name
https://github.com/EddieHubCommunity/EddieBotLive

```diff
- link: 'https://github.com/EddieHubCommunity/EddieBotMap',
+ link: 'https://github.com/EddieHubCommunity/EddieBotLive',
```