### PR TITLE
fix: load images and iframe after document loads #167

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,15 +1,25 @@
 <script>
+  import { onMount } from 'svelte';
   import Card from './Card.svelte';
   import HorizontalCard from './HorizontalCard.svelte';
   import Footer from './Footer.svelte';
   import { footerData, moderators, projects } from './data';
 
+  function init() {
+    const imgs = document.querySelectorAll('[data-src]');
+    imgs.forEach(function(element) {
+      if(element.getAttribute('data-src')) {
+        element.setAttribute('src', element.getAttribute('data-src'));
+      }
+    })
+  }
+  onMount(init());
 </script>
 
 <div
   class="min-w-screen min-h-screen bg-gray-900 flex flex-col items-center justify-center px-5 py-5"
 >
-  <iframe class="w-full md:w-1/4 h-56" src="https://www.youtube.com/embed/z-FKAC0I_VQ" title="EddieHub Community"
+  <iframe class="w-full md:w-1/4 h-56" src="" data-src="https://www.youtube.com/embed/z-FKAC0I_VQ" title="EddieHub Community"
     frameborder="0" allow="accelerometer; clipboard-write; autoplay=1; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
   <h3

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -12,7 +12,8 @@
   target="_blank"
 >
   <img
-    src="{imageSrc}"
+    src=""
+    data-src="{imageSrc}"
     alt="Sample Project"
     class="w-full h-64 object-cover"
   />


### PR DESCRIPTION
This change makes it so the images and the iframe load after the document is loaded. Partially completes #167
Deskop:
Before 41 -> After 51
![desktop_eddiehub_after](https://user-images.githubusercontent.com/17693494/117232822-3432f880-addf-11eb-97fc-25c372c70e46.png)
Mobile:
Before 58 -> After 93
![mobile_eddiehub_after](https://user-images.githubusercontent.com/17693494/117232825-36955280-addf-11eb-87a6-93f7d530c68f.png)

