### PR TITLE
CI (workflows): bump action versions in workflows, fix Node deprecation warnings

### DIFF
--- a/.github/workflows/alex.yml
+++ b/.github/workflows/alex.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 12.x
     - name: Comment on new PR
-      uses: brown-ccv/alex-recommends@v1.1.2
+      uses: brown-ccv/alex-recommends@v1.2.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -16,7 +16,7 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: EddieHubCommunity/gh-action-community/src/welcome@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
   statistics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: EddieHubCommunity/gh-action-community/src/statistics@main
         with:
           firebase-key: ${{ secrets.FIREBASE_KEY }}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

This PR fixes the Node 12 deprecation warning in the action runs.

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- Bump the `actions/checkout` version from `v1`, `v2` (Node 12) to `v3` (Node 16).
- Bump the `actions/setup-node` version to `v3`.
- Bump the `brown-ccv/alex-recommends` version to `v1.2.1`.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
