### PR TITLE
Fix: Make newsletter iframe responsive on mobile

### DIFF
--- a/src/components/Newsletter.jsx
+++ b/src/components/Newsletter.jsx
@@ -18,7 +18,7 @@ export function Newsletter() {
           <div className="my-4">
             <iframe
               src="https://eddiehub.substack.com/embed"
-              className="rounded"
+              className="w-full rounded"
               width="480"
               height="150"
               frameBorder="0"


### PR DESCRIPTION
This pull request aims to resolve issue #304, which addresses a problem with the newsletter iframe breaking on the mobile version of the project. To fix this issue, the pull request introduces a "full-width" CSS class to the newsletter iframe, ensuring that it adapts to the mobile screen width.

## Fixes Issue

Closes #304 

## Changes proposed

- [x] Added a "w-full" tailwind class to the newsletter iframe.
- [x] Ensured that the iframe now resizes correctly to fit the mobile screen width

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="408" alt="Screenshot 2023-11-05 at 02 24 24" src="https://github.com/EddieHubCommunity/EddieHubCommunity.github.io/assets/42172453/28fce8e5-80f2-4a3a-9551-d74aaa05a6f9">


## Note to reviewers
